### PR TITLE
Chore/rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Bottom line : One DataSourceName per test and you have full test isolation in no
 ## Installation
 
 ```
-  go get github.com/proullon/ramsql
+  go get github.com/mallowfields/ramsql
 ```
 
 ## Usage 
@@ -58,7 +58,7 @@ import (
 	"fmt"
 	"testing"
 
-	_ "github.com/proullon/ramsql/driver"
+	_ "github.com/mallowfields/ramsql/driver"
 )
 
 
@@ -118,7 +118,7 @@ CREATE TABLE IF NOT EXISTS user_addresses (address_id INT, user_id INT);
 You may want to test its validity:
 
 ```console
-$ go install github.com/proullon/ramsql
+$ go install github.com/mallowfields/ramsql
 $ ramsql < schema.sql
 ramsql> Query OK. 1 rows affected
 ramsql> Query OK. 1 rows affected

--- a/bench_test.go
+++ b/bench_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	_ "github.com/lib/pq"
-	_ "github.com/proullon/ramsql/driver"
+	_ "github.com/mallowfields/ramsql/driver"
 )
 
 func benchmarkInsert(b *testing.B, driver string, nbRows int) {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/proullon/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/log"
 )
 
 func init() {

--- a/driver/autoincrement_test.go
+++ b/driver/autoincrement_test.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/proullon/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/log"
 )
 
 func TestAutoIncrementSimple(t *testing.T) {

--- a/driver/conn.go
+++ b/driver/conn.go
@@ -4,8 +4,8 @@ import (
 	"database/sql/driver"
 	"sync"
 
-	"github.com/proullon/ramsql/engine/log"
-	"github.com/proullon/ramsql/engine/protocol"
+	"github.com/mallowfields/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/protocol"
 )
 
 // Conn implements sql/driver Conn interface

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/proullon/ramsql/engine"
-	"github.com/proullon/ramsql/engine/log"
-	"github.com/proullon/ramsql/engine/protocol"
+	"github.com/mallowfields/ramsql/engine"
+	"github.com/mallowfields/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/protocol"
 )
 
 func init() {

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -700,6 +700,9 @@ func TestDefaultTimestamp(t *testing.T) {
 		t.Fatalf("expected localtimestamp, got 0")
 	}
 
+	// Sleep for a tiny amount to ensure a different timestamp
+	time.Sleep(100 * time.Millisecond)
+
 	query = `UPDATE pokemon SET seen = current_timestamp WHERE name = 'Charmander'`
 	_, err = db.Exec(query)
 	if err != nil {
@@ -719,6 +722,9 @@ func TestDefaultTimestamp(t *testing.T) {
 	if seen2 == seen {
 		t.Fatalf("expected different value after update")
 	}
+
+	// Sleep for a tiny amount to ensure a different timestamp
+	time.Sleep(100 * time.Millisecond)
 
 	// Check with NOW()
 	query = `UPDATE pokemon SET seen = NOW() WHERE name = 'Charmander'`

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/proullon/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/log"
 )
 
 func TestCreateTable(t *testing.T) {
@@ -305,7 +305,7 @@ func TestCompareDateGT(t *testing.T) {
 
 	query := "SELECT dat FROM comp WHERE dat > '2018-03-03'"
 
-	rows, err := db.Query(query, )
+	rows, err := db.Query(query)
 	if err != nil {
 		t.Fatalf("sql.Query: %s", err)
 	}
@@ -362,7 +362,7 @@ func TestCompareDateLT(t *testing.T) {
 
 	query := "SELECT dat FROM comp WHERE dat < '2019-03-03'"
 
-	rows, err := db.Query(query, )
+	rows, err := db.Query(query)
 	if err != nil {
 		t.Fatalf("sql.Query: %s", err)
 	}

--- a/driver/gorp_test.go
+++ b/driver/gorp_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/go-gorp/gorp"
 
-	"github.com/proullon/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/log"
 )
 
 func TestGorp(t *testing.T) {

--- a/driver/in_test.go
+++ b/driver/in_test.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/proullon/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/log"
 )
 
 func TestIn(t *testing.T) {

--- a/driver/join_test.go
+++ b/driver/join_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/go-gorp/gorp"
 
-	"github.com/proullon/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/log"
 )
 
 type User struct {

--- a/driver/rows.go
+++ b/driver/rows.go
@@ -7,8 +7,8 @@ import (
 	"io"
 	"sync"
 
-	"github.com/proullon/ramsql/engine/log"
-	"github.com/proullon/ramsql/engine/parser"
+	"github.com/mallowfields/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/parser"
 )
 
 // Rows implements the sql/driver Rows interface

--- a/driver/stmt.go
+++ b/driver/stmt.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/proullon/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/log"
 )
 
 // Stmt implements the Statement interface of sql/driver

--- a/driver/tx_test.go
+++ b/driver/tx_test.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/proullon/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/log"
 )
 
 func TestTransaction(t *testing.T) {

--- a/engine/attribute.go
+++ b/engine/attribute.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/proullon/ramsql/engine/log"
-	"github.com/proullon/ramsql/engine/parser"
+	"github.com/mallowfields/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/parser"
 )
 
 // Domain is the set of allowable values for an Attribute.

--- a/engine/condition.go
+++ b/engine/condition.go
@@ -3,8 +3,8 @@ package engine
 import (
 	"fmt"
 
-	"github.com/proullon/ramsql/engine/parser"
-	"github.com/proullon/ramsql/engine/protocol"
+	"github.com/mallowfields/ramsql/engine/parser"
+	"github.com/mallowfields/ramsql/engine/protocol"
 )
 
 func ifExecutor(e *Engine, ifDecl *parser.Decl, conn protocol.EngineConn) error {

--- a/engine/delete.go
+++ b/engine/delete.go
@@ -4,9 +4,9 @@ import (
 	// "errors"
 	"fmt"
 
-	"github.com/proullon/ramsql/engine/log"
-	"github.com/proullon/ramsql/engine/parser"
-	"github.com/proullon/ramsql/engine/protocol"
+	"github.com/mallowfields/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/parser"
+	"github.com/mallowfields/ramsql/engine/protocol"
 )
 
 func deleteExecutor(e *Engine, deleteDecl *parser.Decl, conn protocol.EngineConn) error {

--- a/engine/delete_test.go
+++ b/engine/delete_test.go
@@ -4,9 +4,9 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/proullon/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/log"
 
-	_ "github.com/proullon/ramsql/driver"
+	_ "github.com/mallowfields/ramsql/driver"
 )
 
 func TestTrunc(t *testing.T) {

--- a/engine/drop.go
+++ b/engine/drop.go
@@ -3,8 +3,8 @@ package engine
 import (
 	"fmt"
 
-	"github.com/proullon/ramsql/engine/parser"
-	"github.com/proullon/ramsql/engine/protocol"
+	"github.com/mallowfields/ramsql/engine/parser"
+	"github.com/mallowfields/ramsql/engine/protocol"
 )
 
 func dropExecutor(e *Engine, dropDecl *parser.Decl, conn protocol.EngineConn) error {

--- a/engine/drop_test.go
+++ b/engine/drop_test.go
@@ -4,9 +4,9 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/proullon/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/log"
 
-	_ "github.com/proullon/ramsql/driver"
+	_ "github.com/mallowfields/ramsql/driver"
 )
 
 func TestDrop(t *testing.T) {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"sync"
 
-	"github.com/proullon/ramsql/engine/log"
-	"github.com/proullon/ramsql/engine/parser"
-	"github.com/proullon/ramsql/engine/protocol"
+	"github.com/mallowfields/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/parser"
+	"github.com/mallowfields/ramsql/engine/protocol"
 )
 
 type executor func(*Engine, *parser.Decl, protocol.EngineConn) error

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -3,7 +3,7 @@ package engine
 import (
 	"testing"
 
-	"github.com/proullon/ramsql/engine/protocol"
+	"github.com/mallowfields/ramsql/engine/protocol"
 )
 
 type TestEngineConn struct {

--- a/engine/insert.go
+++ b/engine/insert.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/proullon/ramsql/engine/log"
-	"github.com/proullon/ramsql/engine/parser"
-	"github.com/proullon/ramsql/engine/protocol"
+	"github.com/mallowfields/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/parser"
+	"github.com/mallowfields/ramsql/engine/protocol"
 )
 
 /*

--- a/engine/join.go
+++ b/engine/join.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/proullon/ramsql/engine/log"
-	"github.com/proullon/ramsql/engine/parser"
-	"github.com/proullon/ramsql/engine/protocol"
+	"github.com/mallowfields/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/parser"
+	"github.com/mallowfields/ramsql/engine/protocol"
 )
 
 // virtualRow is the resultset after FROM and JOIN transformations

--- a/engine/join_test.go
+++ b/engine/join_test.go
@@ -4,9 +4,9 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/proullon/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/log"
 
-	_ "github.com/proullon/ramsql/driver"
+	_ "github.com/mallowfields/ramsql/driver"
 )
 
 func TestJoinOrderBy(t *testing.T) {

--- a/engine/limit.go
+++ b/engine/limit.go
@@ -1,8 +1,8 @@
 package engine
 
 import (
-	"github.com/proullon/ramsql/engine/log"
-	"github.com/proullon/ramsql/engine/protocol"
+	"github.com/mallowfields/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/protocol"
 )
 
 type limit struct {

--- a/engine/operator.go
+++ b/engine/operator.go
@@ -2,8 +2,8 @@ package engine
 
 import (
 	"fmt"
-	"github.com/proullon/ramsql/engine/log"
-	"github.com/proullon/ramsql/engine/parser"
+	"github.com/mallowfields/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/parser"
 	"strconv"
 	"time"
 )
@@ -36,7 +36,7 @@ func convToDate(t interface{}) (time.Time, error) {
 		log.Debug("convToDate> unexpected type %T\n", t)
 		return time.Time{}, fmt.Errorf("unexpected internal type %T", t)
 	case string:
-		d, err :=parser.ParseDate(string(t))
+		d, err := parser.ParseDate(string(t))
 		if err != nil {
 			return time.Time{}, fmt.Errorf("cannot parse date %v", t)
 		}

--- a/engine/orderby.go
+++ b/engine/orderby.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/proullon/ramsql/engine/log"
-	"github.com/proullon/ramsql/engine/parser"
-	"github.com/proullon/ramsql/engine/protocol"
+	"github.com/mallowfields/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/parser"
+	"github.com/mallowfields/ramsql/engine/protocol"
 )
 
 //    |-> order

--- a/engine/orderby_test.go
+++ b/engine/orderby_test.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/proullon/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/log"
 )
 
 func TestOrderByInt(t *testing.T) {

--- a/engine/parser/drop.go
+++ b/engine/parser/drop.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/proullon/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/log"
 )
 
 func (p *parser) parseDrop() (*Instruction, error) {

--- a/engine/parser/lexer.go
+++ b/engine/parser/lexer.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"unicode"
 
-	"github.com/proullon/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/log"
 )
 
 // SQL Tokens

--- a/engine/parser/log.go
+++ b/engine/parser/log.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-//"github.com/proullon/ramsql/engine/log"
+//"github.com/mallowfields/ramsql/engine/log"
 )
 
 func debug(format string, v ...interface{}) {

--- a/engine/parser/parser.go
+++ b/engine/parser/parser.go
@@ -6,7 +6,7 @@ package parser
 import (
 	"fmt"
 
-	"github.com/proullon/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/log"
 )
 
 // The parser structure holds the parser's internal state.
@@ -510,7 +510,7 @@ func (p *parser) parseQuotedToken() (*Decl, error) {
 	quoted := false
 	quoteToken := DoubleQuoteToken
 
-	if p.is(DoubleQuoteToken) || p.is(BacktickToken){
+	if p.is(DoubleQuoteToken) || p.is(BacktickToken) {
 		quoted = true
 		quoteToken = p.cur().Token
 		if err := p.next(); err != nil {

--- a/engine/parser/parser_test.go
+++ b/engine/parser/parser_test.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"testing"
 
-	"github.com/proullon/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/log"
 )
 
 func TestParserCreateTableSimple(t *testing.T) {
@@ -42,16 +42,16 @@ func TestParserComplete(t *testing.T) {
 }
 
 func TestParserCompleteWithBacktickQuotes(t *testing.T) {
-	query := `CREATE TABLE `+"`"+`user`+"`"+`
+	query := `CREATE TABLE ` + "`" + `user` + "`" + `
 	(
-		`+"`"+`id`+"`"+` INT PRIMARY KEY,
-		`+"`"+`last_name`+"`"+` TEXT,
-		`+"`"+`first_name`+"`"+` TEXT,
-		`+"`"+`email`+"`"+` TEXT,
-		`+"`"+`birth_date`+"`"+` DATE,
-		`+"`"+`country`+"`"+` TEXT,
-		`+"`"+`town`+"`"+` TEXT,
-		`+"`"+`zip_code`+"`"+` TEXT
+		` + "`" + `id` + "`" + ` INT PRIMARY KEY,
+		` + "`" + `last_name` + "`" + ` TEXT,
+		` + "`" + `first_name` + "`" + ` TEXT,
+		` + "`" + `email` + "`" + ` TEXT,
+		` + "`" + `birth_date` + "`" + ` DATE,
+		` + "`" + `country` + "`" + ` TEXT,
+		` + "`" + `town` + "`" + ` TEXT,
+		` + "`" + `zip_code` + "`" + ` TEXT
 	)`
 	parse(query, 1, t)
 }
@@ -91,7 +91,7 @@ func TestSelectAttributeWithQuotedTable(t *testing.T) {
 }
 
 func TestSelectAttributeWithBacktickQuotedTable(t *testing.T) {
-	query := `SELECT `+"`"+`account`+"`"+`.id FROM account WHERE email = 'foo@bar.com'`
+	query := `SELECT ` + "`" + `account` + "`" + `.id FROM account WHERE email = 'foo@bar.com'`
 	parse(query, 1, t)
 }
 
@@ -114,10 +114,10 @@ func TestSelectQuotedTableName(t *testing.T) {
 }
 
 func TestSelectBacktickQuotedTableName(t *testing.T) {
-	query := `SELECT * FROM `+"`"+`account`+"`"+` WHERE 1`
+	query := `SELECT * FROM ` + "`" + `account` + "`" + ` WHERE 1`
 	parse(query, 1, t)
 
-	query = `SELECT * FROM `+"`"+`account`+"`"+``
+	query = `SELECT * FROM ` + "`" + `account` + "`" + ``
 	parse(query, 1, t)
 }
 
@@ -144,7 +144,7 @@ func TestInsertNumberWithQuote(t *testing.T) {
 }
 
 func TestInsertNumberWithBacktickQuote(t *testing.T) {
-	query := `INSERT INTO `+"`"+`account`+"`"+` ('email', 'password', 'age') VALUES ('foo@bar.com', 'tititoto', 4)`
+	query := `INSERT INTO ` + "`" + `account` + "`" + ` ('email', 'password', 'age') VALUES ('foo@bar.com', 'tititoto', 4)`
 	parse(query, 1, t)
 }
 

--- a/engine/protocol/buffer.go
+++ b/engine/protocol/buffer.go
@@ -3,7 +3,7 @@ package protocol
 import (
 	"container/list"
 
-	"github.com/proullon/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/log"
 )
 
 // UnlimitedRowsChannel buffers incomming message from bufferThis channel and forward them to

--- a/engine/protocol/buffer_test.go
+++ b/engine/protocol/buffer_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/proullon/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/log"
 )
 
 func TestBufferChannel(t *testing.T) {

--- a/engine/protocol/channel.go
+++ b/engine/protocol/channel.go
@@ -128,6 +128,12 @@ func (cec *ChannelEngineConn) WriteResult(lastInsertedID int64, rowsAffected int
 
 // WriteError when error occurs
 func (cec *ChannelEngineConn) WriteError(err error) error {
+	defer func() {
+		if werr := recover(); werr != nil {
+			fmt.Println("Error writing to connection channel", werr)
+		}
+	}()
+
 	m := message{
 		Type:  errMessage,
 		Value: []string{err.Error()},

--- a/engine/select.go
+++ b/engine/select.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/proullon/ramsql/engine/log"
-	"github.com/proullon/ramsql/engine/parser"
-	"github.com/proullon/ramsql/engine/protocol"
+	"github.com/mallowfields/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/parser"
+	"github.com/mallowfields/ramsql/engine/protocol"
 )
 
 func attributeExistsInTable(e *Engine, attr string, table string) error {

--- a/engine/select_test.go
+++ b/engine/select_test.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/proullon/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/log"
 )
 
 func TestSelectNoOp(t *testing.T) {

--- a/engine/table.go
+++ b/engine/table.go
@@ -3,8 +3,8 @@ package engine
 import (
 	"fmt"
 
-	"github.com/proullon/ramsql/engine/parser"
-	"github.com/proullon/ramsql/engine/protocol"
+	"github.com/mallowfields/ramsql/engine/parser"
+	"github.com/mallowfields/ramsql/engine/protocol"
 )
 
 // Table is defined by a name and attributes

--- a/engine/table_test.go
+++ b/engine/table_test.go
@@ -3,8 +3,8 @@ package engine
 import (
 	"testing"
 
-	"github.com/proullon/ramsql/engine/log"
-	"github.com/proullon/ramsql/engine/parser"
+	"github.com/mallowfields/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/parser"
 )
 
 func TestCreateTable(t *testing.T) {

--- a/engine/truncate.go
+++ b/engine/truncate.go
@@ -3,9 +3,9 @@ package engine
 import (
 	"fmt"
 
-	"github.com/proullon/ramsql/engine/log"
-	"github.com/proullon/ramsql/engine/parser"
-	"github.com/proullon/ramsql/engine/protocol"
+	"github.com/mallowfields/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/parser"
+	"github.com/mallowfields/ramsql/engine/protocol"
 )
 
 func truncateExecutor(e *Engine, trDecl *parser.Decl, conn protocol.EngineConn) error {

--- a/engine/update.go
+++ b/engine/update.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/proullon/ramsql/engine/log"
-	"github.com/proullon/ramsql/engine/parser"
-	"github.com/proullon/ramsql/engine/protocol"
+	"github.com/mallowfields/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/parser"
+	"github.com/mallowfields/ramsql/engine/protocol"
 )
 
 /*

--- a/engine/update_test.go
+++ b/engine/update_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/proullon/ramsql/engine/log"
+	"github.com/mallowfields/ramsql/engine/log"
 
-	_ "github.com/proullon/ramsql/driver"
+	_ "github.com/mallowfields/ramsql/driver"
 )
 
 func TestUpdateSimple(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/proullon/ramsql
+module github.com/mallowfields/ramsql
 
 require (
 	github.com/go-gorp/gorp v2.0.0+incompatible

--- a/main.go
+++ b/main.go
@@ -4,8 +4,8 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/proullon/ramsql/cli"
-	_ "github.com/proullon/ramsql/driver"
+	"github.com/mallowfields/ramsql/cli"
+	_ "github.com/mallowfields/ramsql/driver"
 )
 
 func main() {


### PR DESCRIPTION
- Updates all module paths to mallowfields repo
- Adds small pauses in TestDefaultTimestamp to ensure timestamps are actually different
- Intentionally swallows and logs panics in `engine/protocol/channel.go -> WriteError` due to send on closed channel, which happens regularly when I use ramsql in unit tests